### PR TITLE
Remove duplicate css

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -162,21 +162,6 @@ a.tag[data-ref]:hover {
 background-color: var(--ls-tag-background-hover-color);
 }
 
-a.tag[data-ref] {
-align-items: center;
-background-color: var(--ls-tag-background-color);
-border-radius: 0.2rem 0.2rem 0.2rem 0.2rem;
-display: inline-flex;
-line-height: 0.8rem;
-padding: 0.3rem 0.4rem 0.3rem 0.4rem;
-white-space: nowrap;
-}
-
-a.tag[data-ref]:hover {
-background-color: var(--ls-tag-background-hover-color);
-}
-
-
 /*****************************************
 Code Mirror
 *****************************************/


### PR DESCRIPTION
I was going to tweak some of the tagging CSS (I would prefer more discrete tags), when I noticed that some of the CSS seemed to be there twice

The bit I removed was exactly identical to the section above it, so I assume it was unneeded (I do not know loads about CSS)